### PR TITLE
Fix spec compliance for IA and NAT

### DIFF
--- a/sections/uspia/uspia.go
+++ b/sections/uspia/uspia.go
@@ -11,11 +11,11 @@ type USPIACoreSegment struct {
 	ProcessingNotice                byte
 	SaleOptOutNotice                byte
 	TargetedAdvertisingOptOutNotice byte
+	SensitiveDataOptOutNotice       byte
 	SaleOptOut                      byte
 	TargetedAdvertisingOptOut       byte
 	SensitiveDataProcessing         []byte
 	KnownChildSensitiveDataConsents byte
-	AdditionalDataProcessingConsent byte
 	MspaCoveredTransaction          byte
 	MspaOptOutOptionMode            byte
 	MspaServiceProviderMode         byte
@@ -45,6 +45,11 @@ func NewUSIACoreSegment(bs *util.BitStream) (USPIACoreSegment, error) {
 		return usia, sections.ErrorHelper("USIASegment.TargetedAdvertisingOptOutNotice", err)
 	}
 
+	usia.SensitiveDataOptOutNotice, err = bs.ReadByte2()
+	if err != nil {
+		return usia, sections.ErrorHelper("USIASegment.SensitiveDataOptOutNotice", err)
+	}
+
 	usia.SaleOptOut, err = bs.ReadByte2()
 	if err != nil {
 		return usia, sections.ErrorHelper("USIASegment.SaleOptOut", err)
@@ -63,11 +68,6 @@ func NewUSIACoreSegment(bs *util.BitStream) (USPIACoreSegment, error) {
 	usia.KnownChildSensitiveDataConsents, err = bs.ReadByte2()
 	if err != nil {
 		return usia, sections.ErrorHelper("USIASegment.KnownChildSensitiveDataConsentsArr", err)
-	}
-
-	usia.AdditionalDataProcessingConsent, err = bs.ReadByte2()
-	if err != nil {
-		return usia, sections.ErrorHelper("USIASegment.AdditionalDataProcessingConsent", err)
 	}
 
 	usia.MspaCoveredTransaction, err = bs.ReadByte2()
@@ -93,11 +93,11 @@ func (segment USPIACoreSegment) Encode(bs *util.BitStream) {
 	bs.WriteByte2(segment.ProcessingNotice)
 	bs.WriteByte2(segment.SaleOptOutNotice)
 	bs.WriteByte2(segment.TargetedAdvertisingOptOutNotice)
+	bs.WriteByte2(segment.SensitiveDataOptOutNotice)
 	bs.WriteByte2(segment.SaleOptOut)
 	bs.WriteByte2(segment.TargetedAdvertisingOptOut)
 	bs.WriteTwoBitField(segment.SensitiveDataProcessing)
 	bs.WriteByte2(segment.KnownChildSensitiveDataConsents)
-	bs.WriteByte2(segment.AdditionalDataProcessingConsent)
 	bs.WriteByte2(segment.MspaCoveredTransaction)
 	bs.WriteByte2(segment.MspaOptOutOptionMode)
 	bs.WriteByte2(segment.MspaServiceProviderMode)

--- a/sections/uspia/uspia_test.go
+++ b/sections/uspia/uspia_test.go
@@ -18,23 +18,20 @@ func TestUSPIA(t *testing.T) {
 	testData := []uspneTestData{
 		{
 			description: "should populate USPIA segments correctly",
-			gppString:   "bSFgmJcA.YA",
-			/*
-				011011 01 00 10 00 01 0110000010011000 10 01 01 11 00 01
-			*/
+			gppString:   "bShYJicA.YA",
 			expected: USPIA{
 				CoreSegment: USPIACoreSegment{
 					Version:                         27,
 					ProcessingNotice:                1,
 					SaleOptOutNotice:                0,
 					TargetedAdvertisingOptOutNotice: 2,
+					SensitiveDataOptOutNotice:       2,
 					SaleOptOut:                      0,
 					TargetedAdvertisingOptOut:       1,
 					SensitiveDataProcessing: []byte{
 						1, 2, 0, 0, 2, 1, 2, 0,
 					},
 					KnownChildSensitiveDataConsents: 2,
-					AdditionalDataProcessingConsent: 1,
 					MspaCoveredTransaction:          1,
 					MspaOptOutOptionMode:            3,
 					MspaServiceProviderMode:         0,
@@ -44,7 +41,7 @@ func TestUSPIA(t *testing.T) {
 					Gpc:            true,
 				},
 				SectionID: constants.SectionUSPIA,
-				Value:     "bSFgmJcA.YA",
+				Value:     "bShYJicA.YA",
 			},
 		},
 	}

--- a/sections/uspnat/uspnat.go
+++ b/sections/uspnat/uspnat.go
@@ -86,12 +86,12 @@ func NewUSPNATCoreSegment(bs *util.BitStream) (USPNATCoreSegment, error) {
 		return uspnatCore, sections.ErrorHelper("CoreSegment.TargetedAdvertisingOptOut", err)
 	}
 
-	uspnatCore.SensitiveDataProcessing, err = bs.ReadTwoBitField(12)
+	uspnatCore.SensitiveDataProcessing, err = bs.ReadTwoBitField(16)
 	if err != nil {
 		return uspnatCore, sections.ErrorHelper("CoreSegment.SensitiveDataProcessing", err)
 	}
 
-	uspnatCore.KnownChildSensitiveDataConsents, err = bs.ReadTwoBitField(2)
+	uspnatCore.KnownChildSensitiveDataConsents, err = bs.ReadTwoBitField(3)
 	if err != nil {
 		return uspnatCore, sections.ErrorHelper("CoreSegment.KnownChildSensitiveDataConsents", err)
 	}

--- a/sections/uspnat/uspnat_test.go
+++ b/sections/uspnat/uspnat_test.go
@@ -18,31 +18,28 @@ func TestUSPNAT(t *testing.T) {
 	testData := []uspnatTestData{
 		{
 			description: "should populate USPNAT segments correctly",
-			gppString:   "DSJgmkoZJSA.YA",
-			/*
-				000011 01 00 10 00 10 01 10 00 00 100110100100101000011001 0010 01 01 00 10 01 1 011
-			*/
+			gppString:   "BaaVEiFKEJJo.YA",
 			expected: USPNAT{
 				CoreSegment: USPNATCoreSegment{
-					Version:                             3,
+					Version:                             1,
 					SharingNotice:                       1,
-					SaleOptOutNotice:                    0,
+					SaleOptOutNotice:                    2,
 					SharingOptOutNotice:                 2,
-					TargetedAdvertisingOptOutNotice:     0,
+					TargetedAdvertisingOptOutNotice:     1,
 					SensitiveDataProcessingOptOutNotice: 2,
-					SensitiveDataLimitUseNotice:         1,
-					SaleOptOut:                          2,
-					SharingOptOut:                       0,
-					TargetedAdvertisingOptOut:           0,
+					SensitiveDataLimitUseNotice:         2,
+					SaleOptOut:                          1,
+					SharingOptOut:                       1,
+					TargetedAdvertisingOptOut:           1,
 					SensitiveDataProcessing: []byte{
-						2, 1, 2, 2, 1, 0, 2, 2, 0, 1, 2, 1,
+						0, 1, 0, 2, 0, 2, 0, 1, 1, 0, 2, 2, 0, 1, 0, 0,
 					},
 					KnownChildSensitiveDataConsents: []byte{
-						0, 2,
+						2, 1, 0,
 					},
-					PersonalDataConsents:    1,
+					PersonalDataConsents:    2,
 					MspaCoveredTransaction:  1,
-					MspaOptOutOptionMode:    0,
+					MspaOptOutOptionMode:    2,
 					MspaServiceProviderMode: 2,
 				},
 				GPCSegment: sections.CommonUSGPCSegment{
@@ -50,7 +47,7 @@ func TestUSPNAT(t *testing.T) {
 					Gpc:            true,
 				},
 				SectionID: constants.SectionUSPNAT,
-				Value:     "DSJgmkoZJSA.YA",
+				Value:     "BaaVEiFKEJJo.YA",
 			},
 		},
 	}

--- a/sections/uspne/uspne.go
+++ b/sections/uspne/uspne.go
@@ -21,7 +21,7 @@ type USPNECoreSegment struct {
 	MspaServiceProviderMode         byte
 }
 
-func NewUSIACoreSegment(bs *util.BitStream) (USPNECoreSegment, error) {
+func NewUSNECoreSegment(bs *util.BitStream) (USPNECoreSegment, error) {
 	var uspne USPNECoreSegment
 	var err error
 
@@ -118,7 +118,7 @@ func NewUSPNE(encoded string) (USPNE, error) {
 		return uspne, err
 	}
 
-	coreSegment, err := NewUSIACoreSegment(coreBitStream)
+	coreSegment, err := NewUSNECoreSegment(coreBitStream)
 	if err != nil {
 		return uspne, err
 	}

--- a/sections/uspnh/uspnh.go
+++ b/sections/uspnh/uspnh.go
@@ -21,7 +21,7 @@ type USPNHCoreSegment struct {
 	MspaServiceProviderMode         byte
 }
 
-func NewUSDECoreSegment(bs *util.BitStream) (USPNHCoreSegment, error) {
+func NewUSNHCoreSegment(bs *util.BitStream) (USPNHCoreSegment, error) {
 	var usnh USPNHCoreSegment
 	var err error
 
@@ -118,7 +118,7 @@ func NewUSPNH(encoded string) (USPNH, error) {
 		return uspnh, err
 	}
 
-	coreSegment, err := NewUSDECoreSegment(coreBitStream)
+	coreSegment, err := NewUSNHCoreSegment(coreBitStream)
 	if err != nil {
 		return uspnh, err
 	}

--- a/sections/uspnj/uspnj.go
+++ b/sections/uspnj/uspnj.go
@@ -21,7 +21,7 @@ type USPNJCoreSegment struct {
 	MspaServiceProviderMode         byte
 }
 
-func NewUSDECoreSegment(bs *util.BitStream) (USPNJCoreSegment, error) {
+func NewUSNJCoreSegment(bs *util.BitStream) (USPNJCoreSegment, error) {
 	var usnj USPNJCoreSegment
 	var err error
 
@@ -118,7 +118,7 @@ func NewUSPNJ(encoded string) (USPNJ, error) {
 		return uspnj, err
 	}
 
-	coreSegment, err := NewUSDECoreSegment(coreBitStream)
+	coreSegment, err := NewUSNJCoreSegment(coreBitStream)
 	if err != nil {
 		return uspnj, err
 	}


### PR DESCRIPTION
- Fixed compliance with IAB spec for IA and NAT
  - IA spec: https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/US-States/IA/GPP%20Extension%3A%20IAB%20Privacy%E2%80%99s%20Iowa%20Privacy%20Technical%20Specification.md
  - NAT spec: https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/US-National/IAB%20Privacy%E2%80%99s%20Multi-State%20Privacy%20Agreement%20(MSPA)%20US%20National%20Technical%20Specification.md
  - See commit descriptions for more details
- Fixed naming of the core segment constructors for NE, NH, NJ. 