### PR TITLE
add TCFv2 support

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -25,7 +25,7 @@ const (
 )
 
 var SectionNamesByID = map[SectionID]string{
-	SectionTCFEU2:       "tcfeu2",
+	SectionTCFEU2:       "tcfeuv2",
 	SectionGPP:          "gpp header",
 	GPPSectionTCFCanada: "tcfcav1",
 	SectionUSPV1:        "uspv1",

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/streamrail/go-gpp
 
 go 1.16
 
-require github.com/stretchr/testify v1.8.1
+require (
+	github.com/prebid/go-gdpr v1.12.1
+	github.com/stretchr/testify v1.8.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,15 @@
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prebid/go-gdpr v1.12.1 h1:mK02GP0jLdrU+PVcGZjceAVdov4n6RA404iC9zmGWIc=
+github.com/prebid/go-gdpr v1.12.1/go.mod h1:mPZAdkRxn+iuSjaUuJAi9+0SppBOdM1PCzv/55UH3pY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=

--- a/parse.go
+++ b/parse.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/streamrail/go-gpp/constants"
+	"github.com/streamrail/go-gpp/sections/tcfeu2"
 	"github.com/streamrail/go-gpp/sections/uspca"
 	"github.com/streamrail/go-gpp/sections/uspco"
 	"github.com/streamrail/go-gpp/sections/uspct"
@@ -105,6 +106,11 @@ func Parse(v string) (GppContainer, []error) {
 			}
 		case constants.SectionUSPCT:
 			sections[i], err = uspct.NewUSPCT(sectionStrings[i+1])
+			if err != nil {
+				errs = append(errs, fmt.Errorf("error parsing %s consent string: %s", constants.SectionNamesByID[id], err))
+			}
+		case constants.SectionTCFEU2:
+			sections[i], err = tcfeu2.NewTCFEU2(sectionStrings[i+1])
 			if err != nil {
 				errs = append(errs, fmt.Errorf("error parsing %s consent string: %s", constants.SectionNamesByID[id], err))
 			}

--- a/parse_test.go
+++ b/parse_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/streamrail/go-gpp/constants"
 	"github.com/streamrail/go-gpp/sections"
+	"github.com/streamrail/go-gpp/sections/tcfeu2"
 	"github.com/streamrail/go-gpp/sections/uspca"
 	"github.com/streamrail/go-gpp/sections/uspva"
 	"github.com/stretchr/testify/assert"
@@ -26,8 +27,10 @@ func TestParse(t *testing.T) {
 			expected: GppContainer{
 				Version:      1,
 				SectionTypes: []constants.SectionID{2},
-				Sections: []Section{GenericSection{sectionID: 2,
-					value: "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA"}},
+				Sections: []Section{tcfeu2.TCFEU2{
+					SectionID: 2,
+					Value:     "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+				}},
 			},
 		},
 		"gpp-tcf-valid-quantum": { // header is valid base64 quantum, should gracefully decode correctly
@@ -36,8 +39,10 @@ func TestParse(t *testing.T) {
 			expected: GppContainer{
 				Version:      1,
 				SectionTypes: []constants.SectionID{2},
-				Sections: []Section{GenericSection{sectionID: 2,
-					value: "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA"}},
+				Sections: []Section{tcfeu2.TCFEU2{
+					SectionID: 2,
+					Value:     "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+				}},
 			},
 		},
 		"gpp-tcf-usp": {
@@ -46,10 +51,13 @@ func TestParse(t *testing.T) {
 			expected: GppContainer{
 				Version:      1,
 				SectionTypes: []constants.SectionID{2, 6},
-				Sections: []Section{GenericSection{sectionID: 2,
-					value: "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA"},
-					GenericSection{sectionID: 6,
-						value: "1YNN"}},
+				Sections: []Section{
+					tcfeu2.TCFEU2{
+						SectionID: 2,
+						Value:     "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+					},
+					GenericSection{sectionID: 6, value: "1YNN"},
+				},
 			},
 		},
 		"gpp-tcfca-usp": {
@@ -131,8 +139,10 @@ func TestParse(t *testing.T) {
 			expected: GppContainer{
 				Version:      1,
 				SectionTypes: []constants.SectionID{2},
-				Sections: []Section{GenericSection{sectionID: 2,
-					value: "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA"}},
+				Sections: []Section{tcfeu2.TCFEU2{
+					SectionID: 2,
+					Value:     "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+				}},
 			},
 			expectedError: []error{fmt.Errorf("error parsing GPP header, section identifiers: error reading an int offset value in a Range(Fibonacci) entry(1): error reading bit 4 of Integer(Fibonacci): expected 1 bit at bit 32, but the byte array was only 4 bytes long")},
 		},
@@ -149,7 +159,22 @@ func TestParse(t *testing.T) {
 
 			if len(test.expectedError) == 0 {
 				assert.Nil(t, err)
-				assert.Equal(t, test.expected, result)
+				assert.Equal(t, test.expected.Version, result.Version)
+				assert.Equal(t, test.expected.SectionTypes, result.SectionTypes)
+				if assert.Len(t, result.Sections, len(test.expected.Sections)) {
+					for i, s := range result.Sections {
+						expectedSection := test.expected.Sections[i]
+						_, isTCF := expectedSection.(tcfeu2.TCFEU2)
+						if isTCF {
+							// We don't check the CoreSegment for TCF
+							assert.Equal(t, expectedSection.GetID(), s.GetID())
+							assert.Equal(t, expectedSection.GetValue(), s.GetValue())
+							continue
+						}
+
+						assert.Equal(t, expectedSection, s)
+					}
+				}
 			} else {
 				assert.Equal(t, test.expectedError, err)
 			}

--- a/sections/tcfeu2/tcfeu2.go
+++ b/sections/tcfeu2/tcfeu2.go
@@ -1,0 +1,36 @@
+package tcfeu2
+
+import (
+	"github.com/prebid/go-gdpr/api"
+	vendorconsent "github.com/prebid/go-gdpr/vendorconsent/tcf2"
+	"github.com/streamrail/go-gpp/constants"
+)
+
+type TCFEU2 struct {
+	SectionID   constants.SectionID
+	Value       string
+	CoreSegment api.VendorConsents
+}
+
+func NewTCFEU2(encoded string) (TCFEU2, error) {
+	consent, err := vendorconsent.ParseString(encoded)
+	return TCFEU2{
+		SectionID:   constants.SectionTCFEU2,
+		Value:       encoded,
+		CoreSegment: consent,
+	}, err
+}
+
+func (tcfeu2 TCFEU2) Encode(gpcIncluded bool) []byte {
+	// TODO there is currently no Go implementation for encoding TCFv2 strings.
+	// As a workaround, we use the original value
+	return []byte(tcfeu2.Value)
+}
+
+func (tcfeu2 TCFEU2) GetID() constants.SectionID {
+	return tcfeu2.SectionID
+}
+
+func (tcfeu2 TCFEU2) GetValue() string {
+	return tcfeu2.Value
+}

--- a/sections/tcfeu2/tcfeu2_test.go
+++ b/sections/tcfeu2/tcfeu2_test.go
@@ -1,0 +1,63 @@
+package tcfeu2
+
+import (
+	"testing"
+	"time"
+
+	consentconstants "github.com/prebid/go-gdpr/consentconstants/tcf2"
+	tcf2 "github.com/prebid/go-gdpr/vendorconsent/tcf2"
+	"github.com/streamrail/go-gpp/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type tcfeu2TestData struct {
+	description string
+	gppString   string
+	expected    func(t *testing.T, s TCFEU2)
+}
+
+func TestTCFEU2(t *testing.T) {
+	testData := []tcfeu2TestData{
+		{
+			description: "should populate TCFEU2 segments correctly",
+			gppString:   "CQWf88AQWf88APoABAENB4EIAIAAAIAAAAAAE0wAQE0gTTABATSAAAAA.QAAA.IAAA", // Generated with https://iabgpp.com
+			expected: func(t *testing.T, s TCFEU2) {
+				assert.Equal(t, constants.SectionTCFEU2, s.GetID())
+				assert.Equal(t, uint16(1000), s.CoreSegment.CmpID())
+				assert.Equal(t, uint16(1), s.CoreSegment.CmpVersion())
+				assert.Equal(t, "EN", s.CoreSegment.ConsentLanguage())
+				assert.Equal(t, uint8(0), s.CoreSegment.ConsentScreen())
+				assert.Equal(t, time.Date(2025, 8, 21, 2, 0, 0, 0, time.Local), s.CoreSegment.Created())
+				assert.Equal(t, time.Date(2025, 8, 21, 2, 0, 0, 0, time.Local), s.CoreSegment.LastUpdated())
+				assert.Equal(t, uint16(0x269), s.CoreSegment.MaxVendorID())
+				assert.Equal(t, uint8(4), s.CoreSegment.TCFPolicyVersion())
+				assert.True(t, s.CoreSegment.PurposeAllowed(consentconstants.InfoStorageAccess))
+				assert.False(t, s.CoreSegment.PurposeAllowed(consentconstants.ContentPerformance))
+				assert.True(t, s.CoreSegment.VendorConsent(617))
+				assert.False(t, s.CoreSegment.VendorConsent(658))
+				assert.Equal(t, uint16(120), s.CoreSegment.VendorListVersion())
+				assert.Equal(t, uint8(2), s.CoreSegment.Version())
+				assert.Equal(t, "CQWf88AQWf88APoABAENB4EIAIAAAIAAAAAAE0wAQE0gTTABATSAAAAA.QAAA.IAAA", s.GetValue())
+				assert.Equal(t, "CQWf88AQWf88APoABAENB4EIAIAAAIAAAAAAE0wAQE0gTTABATSAAAAA.QAAA.IAAA", string(s.Encode(false)))
+
+				consentMeta, ok := s.CoreSegment.(tcf2.ConsentMetadata)
+				if !ok {
+					assert.FailNow(t, "parsed consent type assert to tcf2.ConsentMetadata failed")
+				}
+				assert.True(t, consentMeta.PurposeLITransparency(consentconstants.InfoStorageAccess))
+				assert.False(t, consentMeta.PurposeLITransparency(consentconstants.ContentPerformance))
+				assert.True(t, consentMeta.SpecialFeatureOptIn(1))
+				assert.False(t, consentMeta.SpecialFeatureOptIn(2))
+				assert.True(t, consentMeta.VendorLegitInterest(617))
+				assert.False(t, consentMeta.VendorLegitInterest(658))
+			},
+		},
+	}
+
+	for _, test := range testData {
+		result, err := NewTCFEU2(test.gppString)
+		require.Nil(t, err)
+		test.expected(t, result)
+	}
+}


### PR DESCRIPTION
This PR adds support for parsing the TCFv2 section in order to apply GDPR.